### PR TITLE
Resolving Warnings

### DIFF
--- a/app/src/main/java/br/ecosynergy_app/room/invites/Invites.kt
+++ b/app/src/main/java/br/ecosynergy_app/room/invites/Invites.kt
@@ -2,6 +2,7 @@ package br.ecosynergy_app.room.invites
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import br.ecosynergy_app.room.teams.Teams
 
@@ -12,7 +13,8 @@ import br.ecosynergy_app.room.teams.Teams
         parentColumns = ["id"],
         childColumns = ["teamId"],
         onDelete = ForeignKey.CASCADE
-    )]
+    )],
+    indices = [Index(value = ["teamId"])]
 )
 data class Invites (
     @PrimaryKey(autoGenerate = false) val id: Int,

--- a/app/src/main/java/br/ecosynergy_app/room/readings/FireReading.kt
+++ b/app/src/main/java/br/ecosynergy_app/room/readings/FireReading.kt
@@ -2,6 +2,7 @@ package br.ecosynergy_app.room.readings
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import br.ecosynergy_app.room.teams.Teams
 
@@ -12,7 +13,8 @@ import br.ecosynergy_app.room.teams.Teams
         parentColumns = ["handle"],
         childColumns = ["teamHandle"],
         onDelete = ForeignKey.CASCADE
-    )]
+    )],
+    indices = [Index(value = ["teamHandle"])]
 )
 data class FireReading(
     @PrimaryKey(autoGenerate = false) val id: Int,

--- a/app/src/main/java/br/ecosynergy_app/room/readings/MQ135Reading.kt
+++ b/app/src/main/java/br/ecosynergy_app/room/readings/MQ135Reading.kt
@@ -2,6 +2,7 @@ package br.ecosynergy_app.room.readings
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import br.ecosynergy_app.room.teams.Teams
 
@@ -12,7 +13,8 @@ import br.ecosynergy_app.room.teams.Teams
         parentColumns = ["handle"],
         childColumns = ["teamHandle"],
         onDelete = ForeignKey.CASCADE
-    )]
+    )],
+    indices = [Index(value = ["teamHandle"])]
 )
 data class MQ135Reading(
     @PrimaryKey(autoGenerate = false) val id: Int,

--- a/app/src/main/java/br/ecosynergy_app/room/readings/MQ7Reading.kt
+++ b/app/src/main/java/br/ecosynergy_app/room/readings/MQ7Reading.kt
@@ -2,6 +2,7 @@ package br.ecosynergy_app.room.readings
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import br.ecosynergy_app.room.teams.Teams
 
@@ -12,7 +13,8 @@ import br.ecosynergy_app.room.teams.Teams
         parentColumns = ["handle"],
         childColumns = ["teamHandle"],
         onDelete = ForeignKey.CASCADE
-    )]
+    )],
+    indices = [Index(value = ["teamHandle"])]
 )
 data class MQ7Reading(
     @PrimaryKey(autoGenerate = false) val id: Int,

--- a/app/src/main/java/br/ecosynergy_app/room/teams/Members.kt
+++ b/app/src/main/java/br/ecosynergy_app/room/teams/Members.kt
@@ -2,6 +2,7 @@ package br.ecosynergy_app.room.teams
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
+import androidx.room.Index
 
 @Entity(
     tableName = "members",
@@ -13,7 +14,8 @@ import androidx.room.ForeignKey
             onDelete = ForeignKey.CASCADE
         )
     ],
-    primaryKeys = ["userId", "teamId"]
+    primaryKeys = ["userId", "teamId"],
+    indices = [Index(value = ["teamId"])]
 )
 data class Members(
     val userId: Int,


### PR DESCRIPTION
**Description**
This pull request addresses warnings related to foreign key columns in the members and fire_readings tables, which lacked indexing and could cause full table scans.

**Main Changes**

- members table: Added an index on the teamId column, which is used as a foreign key, to optimize operations and improve query performance.
- fire_readings table: Added an index on the teamHandle column, also used as a foreign key, to prevent full table scans when the parent table (teams) is modified.

**Purpose**
These adjustments help the system avoid full table scans on operations involving these foreign keys, resulting in improved performance.